### PR TITLE
[MRG] Update sklearn minimum version

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -59,7 +59,7 @@ The dependency requirements are based on the last scikit-learn release:
 
 * scipy(>=0.19.1)
 * numpy(>=1.13.3)
-* scikit-learn(>=0.23)
+* scikit-learn(>=0.24)
 * joblib(>=0.11)
 * keras 2 (optional)
 * tensorflow (optional)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn-contrib/imbalanced-learn/blob/master/CONTRIBUTING.md#contributing-pull-requests
-->
#### Reference Issue
Fixes #839

#### What does this implement/fix? Explain your changes.
The minimum version for scikit-learn was outdated; the change was introduced in this commit https://github.com/scikit-learn-contrib/imbalanced-learn/commit/f40e654c20c9c6ec4d77904278f0560997347fa9 but the README.rst was never 

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.

Thanks for contributing!
-->
